### PR TITLE
Use ORT main branch instead of master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 [submodule "oss-review-toolkit"]
 	path = oss-review-toolkit
 	url = https://github.com/oss-review-toolkit/ort
-	branch = master
+	branch = main
 [submodule "opossum.lib.hs"]
 	path = opossum.lib.hs
 	url = git@github.com:opossum-tool/opossum.lib.hs


### PR DESCRIPTION
There is no master branch any longer for ORT: 
https://github.com/oss-review-toolkit/ort/branches

